### PR TITLE
fix: Iist out of range

### DIFF
--- a/weibo/spiders/search.py
+++ b/weibo/spiders/search.py
@@ -403,7 +403,8 @@ class SearchSpider(scrapy.Spider):
                 weibo['topics'] = self.get_topics(txt_sel)
                 reposts_count = sel.xpath(
                     './/a[@action-type="feed_list_forward"]/text()').extract(
-                    )[1]
+                    )
+                reposts_count = "".join(reposts_count)
                 try:
                     reposts_count = re.findall(r'\d+.*', reposts_count)
                 except TypeError:


### PR DESCRIPTION
部分微博的"转发按钮"的 extract 返回值是空, 或长度为1的列表, 此时会发生 list out of range 错误, 本提交修复了这个问题. 方式是, 将列表的所有元素组合成一个字符串, 这样等价于将 <a> 标签中所有的 text 位置的文本提取出来, 一些元素是空字符串, 一个元素包含转发数, 组合成字符串后经过正则, 能得到正确的转发数.